### PR TITLE
Update dependencies

### DIFF
--- a/Classes/Command/UpdateLibraryCommand.php
+++ b/Classes/Command/UpdateLibraryCommand.php
@@ -79,7 +79,7 @@ class UpdateLibraryCommand extends Command
             $response = $requestFactory->request($url);
             if ($response->getStatusCode() === 200) {
                 GeneralUtility::writeFile($targetFile, $response->getBody()->getContents());
-                $process = new Process('tar --strip-components=1 -xz --exclude=*txt -f ' . $targetFile, $targetPath);
+                $process = new Process(['tar', '--strip-components=1', '-xz', '--exclude=*txt', '-f',  $targetFile], $targetPath);
                 $process->run();
                 unlink($targetFile);
             }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"typo3/cms-core": "^8.7 || ^9.0 || ^10.0 || ^11.0",
-		"symfony/process": "^2.8 || ^3.0 || ^4.0 || ^5.0",
+		"symfony/process": "^4.2 || ^5.0",
 		"geoip2/geoip2": "^2.8"
 	},
 	"extra": {

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
 	"description": "Magnets: TYPO3 Service Package revolving around having a good API to fetch the current Geo IP and its location of the user.",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"typo3/cms-core": "^8.7 || ^9.0 || ^10.0",
-		"symfony/process": "^2.8 || ^3.0 || ^4.0",
+		"typo3/cms-core": "^8.7 || ^9.0 || ^10.0 || ^11.0",
+		"symfony/process": "^2.8 || ^3.0 || ^4.0 || ^5.0",
 		"geoip2/geoip2": "^2.8"
 	},
 	"extra": {


### PR DESCRIPTION
Symfony Process 4.2 deprecated calling `new Process()` with a string.
An array is expected in its place.