### PR TITLE
[FEATURE] Add expression language "countryCode" condition

### DIFF
--- a/Classes/Command/UpdateLibraryCommand.php
+++ b/Classes/Command/UpdateLibraryCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace B13\Magnets\Command;
 
 /*
- * This file is part of TYPO3 CMS-based project magnets by b13.
+ * This file is part of TYPO3 CMS-based extension "magnets" by b13.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2

--- a/Classes/Command/UpdateLibraryCommand.php
+++ b/Classes/Command/UpdateLibraryCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace B13\Magnets\Command;
 
 /*
- * This file is part of TYPO3 CMS-based project dbaudio by b13.
+ * This file is part of TYPO3 CMS-based project magnets by b13.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2
@@ -48,8 +48,8 @@ class UpdateLibraryCommand extends Command
         $this->io->title($this->getDescription());
 
         if (empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['GeoIPLicenceKey'])) {
-            $this->io->error('please provide a licence key, see README.md');
-            return 1;
+            $this->io->error('Provide a licence key, see README.md');
+            return self::FAILURE;
         }
 
         $targetPath = $GLOBALS['TYPO3_CONF_VARS']['SYS']['GeoIPPath'] . '/';
@@ -71,6 +71,6 @@ class UpdateLibraryCommand extends Command
             }
         }
         $this->io->success('Downloaded all files from MaxMind into ' . $targetPath);
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/Classes/ExpressionLanguage/GeoIpConditionProvider.php
+++ b/Classes/ExpressionLanguage/GeoIpConditionProvider.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 namespace B13\Magnets\ExpressionLanguage;
 
 /*
- * This file is part of TYPO3 CMS-based project magnets by b13.
+ * This file is part of TYPO3 CMS-based extension "magnets" by b13.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2
@@ -33,7 +33,7 @@ class GeoIpConditionProvider extends AbstractProvider
 
         // We make the countryCode available in conditions for site configs base variants
         // to enable base URL switches depending on the country code.
-        // e.g. countryCode == 'dk'
+        // e.g. countryCode == 'DK'
         $this->expressionLanguageVariables = [
             'countryCode' => strtoupper($countryCode),
         ];

--- a/Classes/ExpressionLanguage/GeoIpConditionProvider.php
+++ b/Classes/ExpressionLanguage/GeoIpConditionProvider.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types = 1);
+
+namespace B13\Magnets\ExpressionLanguage;
+
+/*
+ * This file is part of TYPO3 CMS-based project magnets by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Magnets\IpLocation;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\ExpressionLanguage\AbstractProvider;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class GeoIpConditionProvider extends AbstractProvider
+{
+    public function __construct()
+    {
+        if (Environment::isCli()) {
+            return;
+        }
+
+        $countryCode = '';
+        $ipAddress = GeneralUtility::getIndpEnv('REMOTE_ADDR');
+        if ($ipAddress) {
+            $location = new IpLocation($ipAddress);
+            $countryCode = $location->getCountryCode();
+        }
+
+        // We make the countryCode available in conditions for site configs base variants
+        // to enable base URL switches depending on the country code.
+        // e.g. countryCode == 'dk'
+        $this->expressionLanguageVariables = [
+            'countryCode' => strtoupper($countryCode),
+        ];
+    }
+}

--- a/Classes/IpLocation.php
+++ b/Classes/IpLocation.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace B13\Magnets;
 
 /*
- * This file is part of TYPO3 CMS-based project magnets by b13.
+ * This file is part of TYPO3 CMS-based extension "magnets" by b13.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2

--- a/Classes/IpLocation.php
+++ b/Classes/IpLocation.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace B13\Magnets;
 
 /*
- * This file is part of TYPO3 CMS-based project dbaudio by b13.
+ * This file is part of TYPO3 CMS-based project magnets by b13.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2

--- a/Configuration/ExpressionLanguage.php
+++ b/Configuration/ExpressionLanguage.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'site' => [
+        \B13\Magnets\ExpressionLanguage\GeoIpConditionProvider::class,
+    ],
+    'typoscript' => [
+        \B13\Magnets\ExpressionLanguage\GeoIpConditionProvider::class,
+    ],
+];

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ In addition, you have "countryCode" as TypoScript condition available.
       page.10.value = You are from france
     [global]
 
+The condition is also available in site configurations.
+
 ## License
 
 Just as TYPO3 Core, this is an extension for TYPO3 and also licensed under GPL2+.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ For download the latest GeoIP2 data you have to provide an licence-key from [max
 
 Run `composer req b13/magnets` and install the extension via Extension Manager.
 
+## Usage
+
+Ensure your cronjob / scheduler task is running and use the IpLocation PHP class to have
+a nice and quick API.
+
+In addition, you have "countryCode" as TypoScript condition available.
+
+    [countryCode == 'FR']
+      page.10 = TEXT
+      page.10.value = You are from france
+    [global]
+
 ## License
 
 Just as TYPO3 Core, this is an extension for TYPO3 and also licensed under GPL2+.


### PR DESCRIPTION
It is now possible to use country information in TypoScript conditions and site conditions.
```
[countryCode == 'FR']
page.10 = TEXT
page.10.value = You are from france
[global]
```

I think this is nice.