### PR TITLE
[BUGFIX] Remove duplicated registration of command

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,9 +6,3 @@ services:
 
   B13\Magnets\:
     resource: '../Classes/*'
-
-  B13\Magnets\Command\UpdateLibraryCommand:
-    tags:
-      - name: 'console.command'
-        command: 'geoip:lib:update'
-        schedulable: true


### PR DESCRIPTION
For some reason, the command does not show up in the list of available commands when calling `bin/typo3` if it is registered both via an attribute in the PHP class and in the Services.yaml file. Removing the latter fixes this problem.